### PR TITLE
bugfix for signature heatmap

### DIFF
--- a/R/SignatureExplorationPlots.R
+++ b/R/SignatureExplorationPlots.R
@@ -194,7 +194,7 @@ plot_signatureClustered <- function(signature_mat,
 
   # calc mean and sd
   df$mean <- rowMeans(df[, -1])
-  df$sd <- apply(df[, 2:(ncol(df) - 1)], 1, sd)
+  df$sd <- apply(df[, 2:(ncol(df) - 1)], 1, sd) + 0.0001 # add pseudocount to not divide by 0 in case of SD=0
 
   # pivot for z-score calc
   df <- tidyr::pivot_longer(df, !c("X", "mean", "sd"), names_to = "cell_type", values_to = "value")


### PR DESCRIPTION
Signature heatmap would crash if you have gene rows with only 0 expression values. Will then get a standard deviation of 0 during z score calculation and dividing by 0.
Fixed by pseudocount added to SD.